### PR TITLE
Fix user controller export and add DB helper stubs

### DIFF
--- a/Documents/ac_career_app/backend/src/controllers/userController.js
+++ b/Documents/ac_career_app/backend/src/controllers/userController.js
@@ -1,5 +1,10 @@
 // backend/src/controllers/userController.js
 
+const {
+  fetchCompletedPathsFromDB,
+  addCompletedPathToDB,
+} = require('../helpers/dbHelpers');
+
 const getCompletedPaths = async (req, res) => {
   try {
     const userId = req.user.sub; // Auth0 user ID
@@ -13,7 +18,7 @@ const getCompletedPaths = async (req, res) => {
   }
 };
 
-const updateCompletedPaths = async (req, res) => {
+const completePath = async (req, res) => {
   try {
     const userId = req.user.sub; // Auth0 user ID
     const { pathId } = req.body;
@@ -23,12 +28,12 @@ const updateCompletedPaths = async (req, res) => {
 
     res.status(200).json({ message: 'Completed paths updated successfully' });
   } catch (error) {
-    console.error('Error updating completed paths:', error);
+  console.error('Error updating completed paths:', error);
     res.status(500).json({ message: 'Server error updating completed paths' });
   }
 };
 
 module.exports = {
   getCompletedPaths,
-  updateCompletedPaths,
+  completePath,
 };

--- a/Documents/ac_career_app/backend/src/helpers/dbHelpers.js
+++ b/Documents/ac_career_app/backend/src/helpers/dbHelpers.js
@@ -1,0 +1,17 @@
+// backend/src/helpers/dbHelpers.js
+// Placeholder database helper functions. Replace with real implementations.
+
+const fetchCompletedPathsFromDB = async (userId) => {
+  // TODO: Query your database for completed paths by userId
+  return [];
+};
+
+const addCompletedPathToDB = async (userId, pathId) => {
+  // TODO: Insert or update the completed path for the user in your database
+  return null;
+};
+
+module.exports = {
+  fetchCompletedPathsFromDB,
+  addCompletedPathToDB,
+};


### PR DESCRIPTION
## Summary
- export `completePath` from the user controller for naming consistency
- add stubbed DB helper functions
- import helpers in the controller

## Testing
- `node node_modules/jest/bin/jest.js --runInBand --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688601629bb8832587d2b0c5263fe4ae